### PR TITLE
Specify tool manifest for .NET tools restoration in build workflow

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -38,7 +38,7 @@ jobs:
         run: dotnet restore
 
       - name: Restore .NET tools
-        run: dotnet tool restore
+        run: dotnet tool restore --tool-manifest AsyncJobsTemplate.WebApi/.config/dotnet-tools.json
 
       - name: Build API
         run: dotnet build --configuration Release --no-restore


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/build-and-deploy.yml` file. The change specifies the tool manifest file to use when restoring .NET tools.
